### PR TITLE
Adicionar Relatório de Estoque Baixo

### DIFF
--- a/StockApp.API/Controllers/LowStockReportController.cs
+++ b/StockApp.API/Controllers/LowStockReportController.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using StockApp.Application.DTOs;
+using StockApp.Application.Interfaces;
+
+namespace StockApp.API.Controllers
+{
+    [Route("api / [controller]")]
+    [ApiController]
+    public class LowStockReportController : ControllerBase
+    {
+        private readonly ILowStockReportService _lowStockReportService;
+        
+        public LowStockReportController(ILowStockReportService lowStockReportService)
+        {
+            _lowStockReportService = lowStockReportService;
+        }
+
+        [HttpGet("low-stock")]
+        public async Task<ActionResult<IEnumerable<LowStockProductDTO>>> GetLowStock([FromQuery] int threshold)
+        {
+            var report = await _lowStockReportService.GetLowStockReport(threshold);
+            return Ok(report);
+        }
+    }
+}

--- a/StockApp.Application/DTOs/LowStockProductDTO.cs
+++ b/StockApp.Application/DTOs/LowStockProductDTO.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StockApp.Application.DTOs
+{
+    public class LowStockProductDTO
+    {
+        public int ProductId { get; set; }
+        public string ProductName { get; set; }
+        public int StockQuantity { get; set; }
+        public int Threshold { get; set; }
+    }
+}

--- a/StockApp.Application/Interfaces/ILowStockReportService.cs
+++ b/StockApp.Application/Interfaces/ILowStockReportService.cs
@@ -1,0 +1,14 @@
+﻿using StockApp.Application.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StockApp.Application.Interfaces
+{
+    public interface ILowStockReportService
+    {
+        Task<IEnumerable<LowStockProductDTO>> GetLowStockReport(int threshold);
+    }
+}

--- a/StockApp.Application/Services/LowStockReportService.cs
+++ b/StockApp.Application/Services/LowStockReportService.cs
@@ -1,0 +1,33 @@
+﻿using StockApp.Application.DTOs;
+using StockApp.Application.Interfaces;
+using StockApp.Domain.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StockApp.Application.Services
+{
+    public class LowStockReportService : ILowStockReportService
+    {
+        private readonly IProductRepository _productRepository;
+
+        public LowStockReportService(IProductRepository productRepository)
+        {
+            _productRepository = productRepository;
+        }
+
+        public async Task<IEnumerable<LowStockProductDTO>> GetLowStockReport(int threshold)
+        {
+            var products = await  _productRepository.GetLowStockAsync(threshold);
+            return products.Select(P => new LowStockProductDTO
+            {
+                ProductId = P.Id,
+                ProductName = P.Name,
+                StockQuantity = P.Stock,
+                Threshold = threshold,
+            });
+        }
+    }
+}

--- a/StockApp.Domain/Interfaces/IProductRepository.cs
+++ b/StockApp.Domain/Interfaces/IProductRepository.cs
@@ -10,5 +10,6 @@ namespace StockApp.Domain.Interfaces
         Task<Product> AddAsync(Product product);
         Task<Product> UpdateAsync(Product product);
         Task<Product> Remove(Product product);
+        Task<IEnumerable<Product>> GetLowStockAsync(int threshold);
     }
 }

--- a/StockApp.Infra.Data/Repositories/ProductRepository.cs
+++ b/StockApp.Infra.Data/Repositories/ProductRepository.cs
@@ -43,5 +43,12 @@ namespace StockApp.Infra.Data.Repositories
             await _productContext.SaveChangesAsync();
             return product;
         }
+
+        public async Task<IEnumerable<Product>> GetLowStockAsync(int threshold)
+        {
+            return await _productContext.Products
+                .Where(propa => propa.Stock < threshold)
+                .ToListAsync();
+        }
     }
 }

--- a/StockApp.Infra.IoC/DependencyInjectionAPI.cs
+++ b/StockApp.Infra.IoC/DependencyInjectionAPI.cs
@@ -25,6 +25,7 @@ namespace StockApp.Infra.IoC
             services.AddScoped<IProductRepository, ProductRepository>();
             services.AddScoped<IProductService, ProductService>();
             services.AddScoped<ICategoryService, CategoryService>();
+            services.AddScoped<ILowStockReportService, LowStockReportService>();
             services.AddSingleton<ISmsService, SmsService>();
             services.AddSingleton<ISmsFeedbackService, SmsFeedbackService>();
             services.AddSingleton<IAnonymousFeedbackService, AnonymousFeedbackService>();


### PR DESCRIPTION
# Task: Adicionar Relatório de Estoque Baixo 
## Descrição
Implemente um endpoint que gera relatórios de produtos com estoque baixo. O endpoint deve aceitar um parâmetro threshold para determinar o limite de estoque abaixo do qual os produtos serão incluídos no relatório.

## Mudanças e Implementações
### 1. Criação do DTO
Foi criado um Data Transfer Object (DTO) chamado LowStockProductDTO para representar os produtos com estoque baixo.

### 2. Criação da Interface de Serviço
Foi criada uma interface chamada ILowStockReportService que define o contrato para o serviço de relatório de estoque baixo. Esta interface contém o método GetLowStockReport que aceita um parâmetro threshold.

### 3. Implementação do Serviço
Foi implementada a classe LowStockReportService que realiza a lógica para buscar os produtos com estoque baixo. Esta classe implementa a interface ILowStockReportService e utiliza o repositório de produtos para obter os dados.

### 4. Criação do Método no Repositório
Foi adicionado o método GetLowStockAsync na interface IProductRepository e sua implementação no ProductRepository. Este método busca os produtos com quantidade de estoque abaixo do limite definido (threshold).

### 5. Criação do Controlador
Foi criado um controlador chamado LowStockReportController com o endpoint GET /api/LowStockReport/low-stock. Este endpoint aceita um parâmetro threshold e retorna uma lista de produtos com estoque baixo.

### 6. Configuração de Injeção de Dependência
Foi atualizado o arquivo DependencyInjectionAPI para registrar as novas dependências (ILowStockReportService).