### PR TITLE
Implementar Endpoint de Atualização em Massa

### DIFF
--- a/StockApp.API/Controllers/ProductsController.cs
+++ b/StockApp.API/Controllers/ProductsController.cs
@@ -66,5 +66,12 @@ namespace StockApp.API.Controllers
             return NoContent();
         }
 
+        [HttpPut("bulk-update")]
+        public async Task<ActionResult> BulkUpdate([FromBody] List<Product> products)
+        {
+            await _productRepository.BulkUpdateAsync(products);
+            return NoContent();
+        }
+
     }
 }

--- a/StockApp.Application/Services/ProductService.cs
+++ b/StockApp.Application/Services/ProductService.cs
@@ -51,5 +51,10 @@ namespace StockApp.Application.Services
             var productEntity = _mapper.Map<Product>(productDto);
             await _productRepository.UpdateAsync(productEntity);
         }
+
+        public async Task BulkUpdateAsync(IEnumerable<Product> products)
+        {
+            await _productRepository.BulkUpdateAsync(products);
+        }
     }
 }

--- a/StockApp.Domain/Interfaces/IProductRepository.cs
+++ b/StockApp.Domain/Interfaces/IProductRepository.cs
@@ -11,5 +11,6 @@ namespace StockApp.Domain.Interfaces
         Task<Product> UpdateAsync(Product product);
         Task<Product> Remove(Product product);
         Task<IEnumerable<Product>> GetLowStockAsync(int threshold);
+        Task BulkUpdateAsync(IEnumerable<Product> products);
     }
 }

--- a/StockApp.Infra.Data/Repositories/ProductRepository.cs
+++ b/StockApp.Infra.Data/Repositories/ProductRepository.cs
@@ -50,5 +50,11 @@ namespace StockApp.Infra.Data.Repositories
                 .Where(propa => propa.Stock < threshold)
                 .ToListAsync();
         }
+        
+        public async Task BulkUpdateAsync(IEnumerable<Product> products)
+        {
+            _productContext.Products.UpdateRange(products);
+            await _productContext.SaveChangesAsync();
+        }
     }
 }


### PR DESCRIPTION
# Task: Implementar Endpoint de Atualização em Massa
## Descrição
Adicione um endpoint que permita atualizar múltiplos produtos em uma única requisição. O endpoint deve aceitar uma lista de produtos no corpo da requisição e atualizar os produtos correspondentes no banco de dados.

## Mudanças e Implementações
### 1. Atualizar o Repositório
Objetivo: Adicionar o método BulkUpdateAsync à interface IProductRepository e implementar esse método na classe ProductRepository.

Interface IProductRepository: Adicionamos a definição do método BulkUpdateAsync que aceita uma coleção de produtos.
Implementação ProductRepository: Implementamos o método BulkUpdateAsync para atualizar múltiplos produtos no banco de dados usando o método UpdateRange do Entity Framework e salvando as mudanças com SaveChangesAsync.
### 2. Adicionar o Controlador
Objetivo: Criar o endpoint PUT /api/Product/bulk-update no controlador ProductController.

Controlador ProductController: Adicionamos o método BulkUpdate que aceita uma lista de produtos no corpo da requisição e chama o serviço de atualização em massa. O método retorna NoContent se a operação for bem-sucedida.