### PR TITLE
(5 pontos) Adicionar Cache de Respostas HTTP

### DIFF
--- a/StockApp.API/Controllers/ProductsController.cs
+++ b/StockApp.API/Controllers/ProductsController.cs
@@ -20,6 +20,7 @@ namespace StockApp.API.Controllers
         }
 
         [HttpGet]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]
         public async Task<ActionResult<IEnumerable<Product>>> GetAll()
         {
             var products = await _productRepository.GetAllAsync();

--- a/StockApp.API/Program.cs
+++ b/StockApp.API/Program.cs
@@ -22,6 +22,8 @@ internal class Program
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();
 
+        builder.Services.AddResponseCaching();
+
         builder.Services.AddSingleton<ITaxService, TaxService>();
 
         builder.Services.AddAuthorization(options =>
@@ -79,6 +81,8 @@ internal class Program
         app.UseRouting();
 
         app.UseAuthorization();
+
+        app.UseResponseCaching();
 
         app.MapControllers();
 


### PR DESCRIPTION
### (5 pontos) Adicionar Cache de Respostas HTTP

### Descrição: Configure o cache de respostas HTTP para melhorar o desempenho.

###  ProductsController
- [ ] diante do fato de que public async Task<ActionResult<IEnumerable<Product>>> GetAll()
        {
            var products = await _productRepository.GetAllAsync(); ja estava criado, foi necessario apensar adicionar 
            " [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any, NoStore = false)]"

### Program.cs

- [ ] adição de codigos para funcionamento total da task implementada 