### PR TITLE
Adicionar Funcionalidade de Upload de Imagem de Produtos

### DIFF
--- a/StockApp.API/Controllers/ProductsController.cs
+++ b/StockApp.API/Controllers/ProductsController.cs
@@ -118,5 +118,25 @@ namespace StockApp.API.Controllers
             var products = await _productRepository.GetFilteredAsync(name, minPrice, maxPrice);
             return Ok(products);
         }
+
+        [HttpPost("{id}/upload-image")]
+        public async Task<IActionResult> UploadImage(int id, IFormFile image)
+        {
+            if (image == null || image.Length == 0)
+            {
+                return BadRequest("Invalid image.");
+            }
+
+            var filePath = Path.Combine("wwwroot/images", $"{id}.jpg");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+
+            using (var stream = new FileStream(filePath, FileMode.Create))
+            {
+                await image.CopyToAsync(stream);
+            }
+
+            return Ok();
+        }
     }
 }

--- a/StockApp.API/Program.cs
+++ b/StockApp.API/Program.cs
@@ -75,6 +75,8 @@ internal class Program
 
         app.UseCors("AllowAll");
         app.UseHttpsRedirection();
+        app.UseStaticFiles();
+        app.UseDirectoryBrowser();
 
         app.UseRouting();
 

--- a/StockApp.API/StockApp.API.csproj
+++ b/StockApp.API/StockApp.API.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.31" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>


### PR DESCRIPTION
# Documentação da Funcionalidade de Upload de Imagem de Produtos
## Descrição
Esta atualização implementa a funcionalidade de upload de imagem para os produtos no projeto StockApp.API. Com essa funcionalidade, os usuários podem fazer upload de imagens associadas aos produtos e armazená-las no servidor.

## Alterações Realizadas
### 1. Adição de Dependência
Foi adicionada a dependência Microsoft.AspNetCore.Http.Abstractions para suportar o upload de arquivos no projeto.

### 2. Modificação no Arquivo .csproj
O arquivo .csproj do projeto StockApp.API foi atualizado para incluir a nova dependência:

Microsoft.AspNetCore.Http.Abstractions
### 3. Adição do Método UploadImage no ProductsController
Foi adicionado um novo método UploadImage no ProductsController para lidar com o upload de imagens.

### 4. Configuração de Arquivos Estáticos no Program.cs
O arquivo Program.cs foi modificado para permitir a configuração de arquivos estáticos e a navegação de diretórios. Isso garante que as imagens carregadas possam ser servidas corretamente.