### PR TITLE
(13 pontos) Implementar Suporte a GraphQL

### DIFF
--- a/StockApp.API/Controllers/ProductsController.cs
+++ b/StockApp.API/Controllers/ProductsController.cs
@@ -200,9 +200,9 @@ namespace StockApp.API.Controllers
                 return BadRequest("Invalid image.");
             }
 
-            var filePath = Path.Combine("wwwroot/images", $"{id}.jpg");
+            var filePath = System.IO.Path.Combine("wwwroot/images", $"{id}.jpg");
 
-            Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(filePath));
 
             using (var stream = new FileStream(filePath, FileMode.Create))
             {

--- a/StockApp.API/GraphQL/Mutation.cs
+++ b/StockApp.API/GraphQL/Mutation.cs
@@ -1,0 +1,16 @@
+﻿using StockApp.Domain.Entities;
+using StockApp.Domain.Interfaces;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StockApp.API.GraphQL
+{
+    public class Mutation
+    {
+        public async Task<Product> AddProduct([Service] IProductRepository productRepository, Product product)
+        {
+            await productRepository.AddAsync(product);
+            return product;
+        }
+    }
+}

--- a/StockApp.API/GraphQL/Query.cs
+++ b/StockApp.API/GraphQL/Query.cs
@@ -1,0 +1,16 @@
+﻿using StockApp.Domain.Entities;
+using StockApp.Domain.Interfaces;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StockApp.API.GraphQL
+{
+    public class Query
+    {
+        public async Task<IQueryable<Product>> GetProducts([Service] IProductRepository productRepository)
+        {
+            var products = await productRepository.GetAllAsync();
+            return products.AsQueryable();
+        }
+    }
+}

--- a/StockApp.API/Program.cs
+++ b/StockApp.API/Program.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Localization;
 using System.Globalization;
 using Microsoft.OpenApi.Models;
 using StockApp.Application.Interfaces;
+using StockApp.API.GraphQL;
 
 
 
@@ -27,6 +28,10 @@ internal class Program
 
         builder.Services.AddEndpointsApiExplorer();
         builder.Services.AddSwaggerGen();
+
+        builder.Services.AddGraphQLServer()
+            .AddQueryType<Query>()
+            .AddMutationType<Mutation>();
 
         builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 
@@ -143,6 +148,8 @@ internal class Program
         app.UseResponseCaching();
 
         app.MapControllers();
+
+        app.MapGraphQL();
 
         app.Run();
     }

--- a/StockApp.API/StockApp.API.csproj
+++ b/StockApp.API/StockApp.API.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.6" />
+    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="13.9.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.31" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.6" />


### PR DESCRIPTION
### (13 pontos) Implementar Suporte a GraphQL
### Descrição: Adicione suporte a GraphQL para consultas mais flexíveis e eficientes.

###  GraphQL, Mutation, Query

- [ ] criação da pasta GraphQL em SotckAppAPI para guardar os arquivos mutation e query
- [ ] criado o arquivo mutation e todo seu código para funcionamento total da implementação de suporte 
- [ ] criado o arquivo query e todo seu código para funcionamento total da implementação de suporte 

### Program 

- [ ] adicionado em program para funcionamento do suporte a GraphQL
using StockApp.API.GraphQL;

builder.Services.AddGraphQLServer()
            .AddQueryType<Query>()
            .AddMutationType<Mutation>();
            
 app.MapGraphQL();

### instalado HotChocolate.AspNetCore e HotChocolate.AspNetCore.Authorization para funcionamento total da task

### ProductsController

- [ ] foi necessário mudar um pouco da formução de producscontroller pois em upload estava dando erro de caminho devido a extensão instalada ter rota igual ou parecida com as instalações  HotChocolate.AspNetCore e HotChocolate.AspNetCore.Authorization
            
