### PR TITLE
Adicionar Testes Unitários para o Controlador UsersController

### DIFF
--- a/StockApp.Domain.Test/StockApp.Domain.Test.csproj
+++ b/StockApp.Domain.Test/StockApp.Domain.Test.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Google.Apis.Admin.Directory.directory_v1" Version="1.68.0.3456" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.31" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />

--- a/StockApp.Domain.Test/UserControllerTests.cs
+++ b/StockApp.Domain.Test/UserControllerTests.cs
@@ -1,0 +1,152 @@
+﻿using Moq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
+using StockApp.API.Controllers;
+using StockApp.API.Resources;
+using StockApp.Application.DTOs;
+using StockApp.Application.Interfaces;
+using StockApp.Domain.Entities;
+using StockApp.Domain.Interfaces;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace StockApp.Domain.Test.Controllers
+{
+    public class UserControllerTests
+    {
+        private readonly Mock<IUserRepository> _userRepositoryMock;
+        private readonly Mock<IUserAuditService> _userAuditServiceMock;
+        private readonly Mock<IStringLocalizer<SharedResource>> _localizerMock;
+        private readonly Mock<IEmailService> _emailServiceMock;
+        private readonly UserController _userController;
+
+        public UserControllerTests()
+        {
+            _userRepositoryMock = new Mock<IUserRepository>();
+            _userAuditServiceMock = new Mock<IUserAuditService>();
+            _localizerMock = new Mock<IStringLocalizer<SharedResource>>();
+            _emailServiceMock = new Mock<IEmailService>();
+
+            _userController = new UserController(
+                _userRepositoryMock.Object,
+                _userAuditServiceMock.Object,
+                _localizerMock.Object,
+                _emailServiceMock.Object
+            );
+        }
+
+        [Fact]
+        public async Task Register_ValidUser_ReturnsOk()
+        {
+            // Arrange
+            var userRegisterDto = new UserRegisterDto
+            {
+                Username = "testuser",
+                Password = "password",
+                Role = "User"
+            };
+
+            // Act
+            var result = await _userController.Register(userRegisterDto);
+
+            // Assert
+            var okResult = Assert.IsType<OkResult>(result);
+            Assert.Equal(200, okResult.StatusCode);
+            _userRepositoryMock.Verify(repo => repo.AddAsync(It.IsAny<User>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ForgotPassword_ValidUser_ReturnsOk()
+        {
+            // Arrange
+            var user = new User { Username = "testuser", Email = "test@example.com" };
+            _userRepositoryMock.Setup(repo => repo.GetByUsernameAsync(It.IsAny<string>())).ReturnsAsync(user);
+
+            var forgotPasswordDto = new ForgotPasswordDto
+            {
+                Username = "testuser",
+                Email = "test@example.com"
+            };
+
+            // Act
+            var result = await _userController.ForgotPassword(forgotPasswordDto);
+
+            // Assert
+            var okResult = Assert.IsType<OkResult>(result);
+            Assert.Equal(200, okResult.StatusCode);
+            _emailServiceMock.Verify(email => email.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _userRepositoryMock.Verify(repo => repo.UpdateAsync(It.IsAny<User>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ForgotPassword_InvalidUser_ReturnsNotFound()
+        {
+            // Arrange
+            _userRepositoryMock.Setup(repo => repo.GetByUsernameAsync(It.IsAny<string>())).ReturnsAsync((User)null);
+
+            var forgotPasswordDto = new ForgotPasswordDto
+            {
+                Username = "nonexistentuser",
+                Email = "wrong@example.com"
+            };
+
+            _localizerMock.Setup(_ => _["UserNotFound"]).Returns(new LocalizedString("UserNotFound", "User not found"));
+
+            // Act
+            var result = await _userController.ForgotPassword(forgotPasswordDto);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            Assert.Equal(404, notFoundResult.StatusCode);
+            Assert.Equal("User not found", notFoundResult.Value);
+        }
+
+        [Fact]
+        public async Task ResetPassword_ValidToken_ReturnsOk()
+        {
+            // Arrange
+            var user = new User { Username = "testuser", PasswordResetToken = "validtoken" };
+            _userRepositoryMock.Setup(repo => repo.GetByUsernameAsync(It.IsAny<string>())).ReturnsAsync(user);
+
+            var resetPasswordDto = new ResetPasswordDto
+            {
+                Username = "testuser",
+                Token = "validtoken",
+                NewPassword = "newpassword"
+            };
+
+            // Act
+            var result = await _userController.ResetPassword(resetPasswordDto);
+
+            // Assert
+            var okResult = Assert.IsType<OkResult>(result);
+            Assert.Equal(200, okResult.StatusCode);
+            _userRepositoryMock.Verify(repo => repo.UpdateAsync(It.IsAny<User>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ResetPassword_InvalidToken_ReturnsNotFound()
+        {
+            // Arrange
+            var user = new User { Username = "testuser", PasswordResetToken = "othertoken" };
+            _userRepositoryMock.Setup(repo => repo.GetByUsernameAsync(It.IsAny<string>())).ReturnsAsync(user);
+
+            var resetPasswordDto = new ResetPasswordDto
+            {
+                Username = "testuser",
+                Token = "invalidtoken",
+                NewPassword = "newpassword"
+            };
+
+            _localizerMock.Setup(_ => _["InvalidToken"]).Returns(new LocalizedString("InvalidToken", "Invalid token"));
+
+            // Act
+            var result = await _userController.ResetPassword(resetPasswordDto);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            Assert.Equal(404, notFoundResult.StatusCode);
+            Assert.Equal("Invalid token", notFoundResult.Value);
+        }
+    }
+}


### PR DESCRIPTION
# Projeto StockApp
Este projeto é uma aplicação de gerenciamento de estoque, construída utilizando .NET Core. Esta documentação cobre a adição de testes unitários para o controlador UserController.
## Adicionando Testes Unitários
Criamos testes unitários para o controlador UserController na pasta StockApp.Domain.Test. Os testes foram organizados na classe UserControllerTests.

## Testes Implementados
### Teste para Registro de Usuário
Método: Register
Descrição: Verifica se o método Register retorna Ok quando um usuário válido é registrado.
Mock: IUserRepository
Asserções: Verifica se o resultado é OkResult e se o método AddAsync do repositório é chamado uma vez.
### Teste para Esqueci Minha Senha

Método: ForgotPassword
Descrição: Verifica se o método ForgotPassword retorna Ok quando um usuário válido solicita a redefinição de senha.
Mocks: IUserRepository, IEmailService
Asserções: Verifica se o resultado é OkResult, se o método SendEmailAsync do serviço de e-mail é chamado uma vez, e se o método UpdateAsync do repositório é chamado uma vez.
### Teste para Esqueci Minha Senha - Usuário Inválido

Método: ForgotPassword
Descrição: Verifica se o método ForgotPassword retorna NotFound quando um usuário inválido solicita a redefinição de senha.
Mocks: IUserRepository, IStringLocalizer
Asserções: Verifica se o resultado é NotFoundObjectResult e se a mensagem de erro correta é retornada.
### Teste para Redefinir Senha com Token Válido

Método: ResetPassword
Descrição: Verifica se o método ResetPassword retorna Ok quando um token de redefinição válido é fornecido.
Mock: IUserRepository
Asserções: Verifica se o resultado é OkResult e se o método UpdateAsync do repositório é chamado uma vez.
### Teste para Redefinir Senha com Token Inválido

Método: ResetPassword
Descrição: Verifica se o método ResetPassword retorna NotFound quando um token de redefinição inválido é fornecido.
Mocks: IUserRepository, IStringLocalizer
Asserções: Verifica se o resultado é NotFoundObjectResult e se a mensagem de erro correta é retornada.
## Ferramentas Utilizadas
xUnit: Framework de testes utilizado para escrever e executar os testes unitários.
Moq: Biblioteca utilizada para criar objetos mock para as interfaces e serviços dependentes.